### PR TITLE
Update to-vo.ts

### DIFF
--- a/packages/interpret-cli/src/transfer/bean/to-vo.ts
+++ b/packages/interpret-cli/src/transfer/bean/to-vo.ts
@@ -103,7 +103,7 @@ export async function toBeanClass(
     console.error(`为${intepretHandle.classPath}添加Interface出错,${err}`);
   }
 
-  methods.push({name: '__fields2java', bodyText});
+  methods.push({name: '__fields2java', returnType: 'object', bodyText});
   let ctorBody = ctorParams
     .map(({name}) => `this.${name}=params.${name};`)
     .join('\n');


### PR DESCRIPTION
对于树形结构数据无类型标注时会有隐式any异常
`由于“__fields2java'”不具有返回类型批注并且在它的一个返回表达式中得到直接或间接引用，因此它隐式具有返回类型 "any"。`
如结构
```ts
export interface IDeptSimpleTree {
  children?: Array<DeptSimpleTree>;
  name?: string;
  id?: number;
  isLeafNode?: boolean;
}
```